### PR TITLE
Pin Werkzeug Version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setuptools.setup(
         'psutil<6.0.0; platform_system=="Windows"',
         "pydantic>=1.9,<1.11",
         'waitress==2.1.2; platform_system=="Windows"',
+        'werkzeug<3.0.0' # Werkzeug 3.x breaks back-compatibility of urls package 
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setuptools.setup(
         'psutil<6.0.0; platform_system=="Windows"',
         "pydantic>=1.9,<1.11",
         'waitress==2.1.2; platform_system=="Windows"',
-        'werkzeug<3.0.0' # Werkzeug 3.x breaks back-compatibility of urls package 
+        "werkzeug<3.0.0",  # Werkzeug 3.x breaks back-compatibility of urls package
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Per Werkzeug change log, removal of previously deprecated code in version 3.0.0 breaks backwards compatability of urls package which is used in flask ~2.2.0.

Version 3.0.0
..
Remove previously deprecated code. [#2768](https://github.com/pallets/werkzeug/pull/2768)
...

